### PR TITLE
Fix meta tag typo 'descriptison'

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>Marco Califano</title>
-  <meta content="" name="descriptison">
+  <meta content="" name="description">
   <meta content="" name="keywords">
 
   <!-- Google Fonts -->

--- a/projects/blog.html
+++ b/projects/blog.html
@@ -3,7 +3,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>Personal Blog</title>
-  <meta content="" name="descriptison">
+  <meta content="" name="description">
   <meta content="" name="keywords">
 
   <!-- Favicons -->

--- a/projects/gan.html
+++ b/projects/gan.html
@@ -3,7 +3,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>Image Generator</title>
-  <meta content="" name="descriptison">
+  <meta content="" name="description">
   <meta content="" name="keywords">
 
   <!-- Favicons -->

--- a/projects/iras.html
+++ b/projects/iras.html
@@ -3,7 +3,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
   
     <title>Image Generator</title>
-    <meta content="" name="descriptison">
+    <meta content="" name="description">
     <meta content="" name="keywords">
   
     <!-- Favicons -->

--- a/projects/ml.html
+++ b/projects/ml.html
@@ -3,7 +3,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>ML-DL WebApp</title>
-  <meta content="" name="descriptison">
+  <meta content="" name="description">
   <meta content="" name="keywords">
 
   <!-- Favicons -->

--- a/projects/musicplayer.html
+++ b/projects/musicplayer.html
@@ -3,7 +3,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
   
     <title>Movie Recommender</title>
-    <meta content="" name="descriptison">
+    <meta content="" name="description">
     <meta content="" name="keywords">
   
     <!-- Favicons -->

--- a/projects/recommender.html
+++ b/projects/recommender.html
@@ -3,7 +3,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
   
     <title>Movie Recommender</title>
-    <meta content="" name="descriptison">
+    <meta content="" name="description">
     <meta content="" name="keywords">
   
     <!-- Favicons -->

--- a/projects/resume.html
+++ b/projects/resume.html
@@ -3,7 +3,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>Resume Section Classifier</title>
-  <meta content="" name="descriptison">
+  <meta content="" name="description">
   <meta content="" name="keywords">
 
   <!-- Favicons -->

--- a/projects/todo.html
+++ b/projects/todo.html
@@ -3,7 +3,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>TODO App</title>
-  <meta content="" name="descriptison">
+  <meta content="" name="description">
   <meta content="" name="keywords">
 
   <!-- Favicons -->

--- a/projects/twitteranalysis.html
+++ b/projects/twitteranalysis.html
@@ -3,7 +3,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
   
     <title>Image Generator</title>
-    <meta content="" name="descriptison">
+    <meta content="" name="description">
     <meta content="" name="keywords">
   
     <!-- Favicons -->

--- a/projects/vdg.html
+++ b/projects/vdg.html
@@ -3,7 +3,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>Video Description Generator</title>
-  <meta content="" name="descriptison">
+  <meta content="" name="description">
   <meta content="" name="keywords">
 
   <!-- Favicons -->


### PR DESCRIPTION
## Summary
- fix a typo in the `description` meta tag across all HTML pages

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685afc91f5fc832a81ba33eb823968c6